### PR TITLE
Use maskable icons

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,12 +5,14 @@
     {
       "src": "/static/img/icons/android-chrome-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/static/img/icons/android-chrome-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ],
   "start_url": "/index.html",


### PR DESCRIPTION
Adding a couple lines to the web app manifest will let Android use the PokeQuest icon as [an adaptive icon](https://maskable.app/?demo=https://raw.githubusercontent.com/imyelo/pokequest-wiki/master/public/static/img/icons/android-chrome-512x512.png) when the PWA is installed.